### PR TITLE
Update eslintrc  "vue/no-v-html": "off"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "block-spacing": "error",
     "no-debugger": "off",
     "no-console": "off",
+    "vue/no-v-html": "off",
     "semi": [
       "error",
       "always"


### PR DESCRIPTION
wir brauchen v-html, daher muss diese Regel auf off gesetzt sein